### PR TITLE
chore: add explicit --silent option

### DIFF
--- a/packages/turbo-scripts/src/build-docker.test.ts
+++ b/packages/turbo-scripts/src/build-docker.test.ts
@@ -60,6 +60,7 @@ test.each(['basic-pnpm-monorepo', 'basic-yarn-monorepo', 'basic-bun-monorepo', '
       packageManager,
       cwd,
       imagePrefix,
+      silent: true,
     });
 
     const serviceContainer0 = await new GenericContainer(run0.image).withExposedPorts(3000).start();
@@ -76,6 +77,7 @@ test.each(['basic-pnpm-monorepo', 'basic-yarn-monorepo', 'basic-bun-monorepo', '
       packageManager,
       cwd,
       imagePrefix,
+      silent: true,
     });
     expect(run1.hash).toEqual(run0.hash);
     expect(run1.image).toEqual(run0.image);
@@ -95,6 +97,7 @@ test.each(['basic-pnpm-monorepo', 'basic-yarn-monorepo', 'basic-bun-monorepo', '
       packageManager,
       cwd,
       imagePrefix,
+      silent: true,
     });
     expect(run2.hash).not.toEqual(run0.hash);
     expect(run2.image).not.toEqual(run0.image);

--- a/packages/turbo-scripts/src/build-docker.ts
+++ b/packages/turbo-scripts/src/build-docker.ts
@@ -7,11 +7,13 @@ export async function buildDocker({
   cwd,
   imagePrefix,
   packageManager,
+  silent,
 }: {
   pkgName: string;
   cwd: string;
   imagePrefix: string;
   packageManager: string;
+  silent: boolean;
 }) {
   const hash = fs.readFileSync(`${cwd}/.turbo-docker/hash`, 'utf-8').trim();
   const image = `${imagePrefix}/${pkgName}:${hash}`;
@@ -64,7 +66,7 @@ export async function buildDocker({
       `GIT_DIRTY=${gitIsDirty}`,
       '.',
     ],
-    { cwd: rootDir },
+    { cwd: rootDir, ...(!silent && { stdio: 'inherit' }) },
   );
 
   return {

--- a/packages/turbo-scripts/src/index.ts
+++ b/packages/turbo-scripts/src/index.ts
@@ -24,5 +24,6 @@ async function main() {
     packageManager,
     cwd,
     imagePrefix: process.argv[2]!,
+    silent: process.argv.includes('--silent'),
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a --silent option for the Docker build command in turbo-scripts to suppress console output during builds.
  * Ideal for cleaner logs in CI and scripted runs; invoke the command with --silent to enable quiet mode.
  * Default behavior remains unchanged (verbose output) if the flag is not provided; no impact on build results or existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->